### PR TITLE
Changes to enable rust bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *.so
 preprocessor
 nemotron-speech
-ggml/
 nemotron-asr.cpp
 
 # Test binaries

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.npy
 preprocessor
 nemotron-speech
+ggml/
+nemotron-asr.cpp
 
 # Test binaries
 test_*

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.bin
 *.o
 *.npy
+*.a
+*.so
 preprocessor
 nemotron-speech
 ggml/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ggml"]
+	path = ggml
+	url = https://github.com/ggml-org/ggml

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,27 @@
 # Makefile for ggml-based NeMo ASR implementation
 
-GGML_DIR = ggml
-GGML_BUILD = $(GGML_DIR)/build
+GGML_DIR ?= ggml
+GGML_BUILD ?= $(GGML_DIR)/build
 
-CXX = g++
-CXXFLAGS = -g -std=c++17 -Wall -Wextra -O2
+CXX ?= g++
+CXXFLAGS ?= -g -std=c++17 -Wall -Wextra -O2
 CXXFLAGS += -I $(GGML_DIR)/include
 CXXFLAGS += -I include
 
-LDFLAGS = -L $(GGML_BUILD)/src
-LDFLAGS += -lggml -lggml-base
-LDFLAGS += -Wl,-rpath,$(GGML_BUILD)/src
-LDFLAGS += -Wl,-rpath,$(GGML_BUILD)/bin
+# Detect static libraries in GGML build directory
+GGML_STATIC_LIBS := $(wildcard $(GGML_BUILD)/src/*.a)
+
+# Configure linking based on whether static libraries are available
+ifneq ($(GGML_STATIC_LIBS),)
+    # Static linking - use .a files directly
+    LDFLAGS += $(GGML_STATIC_LIBS)
+else
+    # Dynamic linking - use -l flags and rpath
+    LDFLAGS += -L $(GGML_BUILD)/src
+    LDFLAGS += -lggml -lggml-base
+    LDFLAGS += -Wl,-rpath,$(GGML_BUILD)/src
+    LDFLAGS += -Wl,-rpath,$(GGML_BUILD)/bin
+endif
 
 # Source files
 GGML_SRCS = src/nemo-ggml.cpp src/preprocessor.cpp

--- a/Makefile
+++ b/Makefile
@@ -8,34 +8,10 @@ CXXFLAGS = -g -std=c++17 -Wall -Wextra -O2
 CXXFLAGS += -I $(GGML_DIR)/include
 CXXFLAGS += -I include
 
-# Check if CUDA backend is available
-CUDA_LIB = $(GGML_BUILD)/src/ggml-cuda/libggml-cuda.so
-CUDA_AVAILABLE = $(shell test -f $(CUDA_LIB) && echo 1 || echo 0)
-
-METAL_LIB = $(GGML_BUILD)/src/ggml-metal/libggml-metal.dylib
-METAL_AVAILABLE = $(shell test -f $(METAL_LIB) && echo 1 || echo 0)
-
 LDFLAGS = -L $(GGML_BUILD)/src
-LDFLAGS += -lggml -lggml-base -lggml-cpu
+LDFLAGS += -lggml -lggml-base
 LDFLAGS += -Wl,-rpath,$(GGML_BUILD)/src
-LDFLAGS += -lm -lpthread
-
-# Add CUDA support if available
-ifeq ($(CUDA_AVAILABLE),1)
-    CXXFLAGS += -DGGML_USE_CUDA
-    LDFLAGS += -L $(GGML_BUILD)/src/ggml-cuda -lggml-cuda
-    LDFLAGS += -Wl,-rpath,$(GGML_BUILD)/src/ggml-cuda
-    LDFLAGS += -L /usr/local/cuda/lib64 -lcudart -lcublas
-    LDFLAGS += -Wl,-rpath,/usr/local/cuda/lib64
-endif
-
-# Add Metal support if available
-ifeq ($(METAL_AVAILABLE),1)
-	CXXFLAGS += -DGGML_USE_METAL
-	LDFLAGS += -L $(GGML_BUILD)/src/ggml-metal -lggml-metal
-	LDFLAGS += -Wl,-rpath,$(GGML_BUILD)/src/ggml-metal
-	LDFLAGS += -framework Metal -framework Foundation
-endif
+LDFLAGS += -Wl,-rpath,$(GGML_BUILD)/bin
 
 # Source files
 GGML_SRCS = src/nemo-ggml.cpp src/preprocessor.cpp

--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,29 @@ LDFLAGS += -Wl,-rpath,$(GGML_BUILD)/bin
 # Source files
 GGML_SRCS = src/nemo-ggml.cpp src/preprocessor.cpp
 GGML_STREAM_SRCS = src/nemo-stream.cpp
+C_WRAPPER_SRCS = src/nemotron_asr_c.cpp
 
 # Original implementation (for comparison tests)
 ORIG_SRCS = src/reference/ggml_weights.cpp src/reference/ops.cpp src/reference/conv_subsampling.cpp src/reference/conformer_modules.cpp src/reference/conformer_encoder.cpp src/reference/rnnt_decoder.cpp src/reference/rnnt_joint.cpp src/reference/greedy_decode.cpp src/reference/tokenizer.cpp
 
-.PHONY: all clean clean_bin test transcribe streaming
+.PHONY: all clean clean_bin test transcribe streaming lib
 
 all: nemotron-asr.cpp
 # test_ggml_weights test_ggml_compute transcribe streaming
 
 streaming: test_streaming nemotron-asr.cpp
+
+# C wrapper library for FFI (static and shared)
+lib: libnemotron_asr.a libnemotron_asr.so
+
+libnemotron_asr.a: $(GGML_SRCS:.cpp=.o) $(GGML_STREAM_SRCS:.cpp=.o) $(C_WRAPPER_SRCS:.cpp=.o)
+	ar rcs $@ $^
+
+libnemotron_asr.so: $(GGML_SRCS) $(GGML_STREAM_SRCS) $(C_WRAPPER_SRCS)
+	$(CXX) $(CXXFLAGS) -fPIC -shared $^ $(LDFLAGS) -o $@
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -fPIC -c $< -o $@
 
 # Test weight loading
 test_ggml_weights: tests/test_weights.cpp $(GGML_SRCS) $(ORIG_SRCS)
@@ -61,6 +74,8 @@ nemotron-asr.cpp: src/transcribe_stream.cpp $(GGML_SRCS) $(GGML_STREAM_SRCS)
 
 clean:
 	rm -f test_ggml_weights test_ggml_compute precompute_encoder_ref transcribe test_streaming transcribe_stream test_python_ref test_preprocessor
+	rm -f libnemotron_asr.a libnemotron_asr.so
+	rm -f src/*.o
 
 clean_bin:
 	rm my_bin/*

--- a/README.md
+++ b/README.md
@@ -52,12 +52,14 @@ Once you have built ggml, you can build this binary
 make nemotron-asr.cpp
 ```
 
+All of the ggml backends that you built with should be available to `nemotron-asr.cpp` through the `--backend` flag.
+
 ## Comparison to [whisper.cpp](https://github.com/ggml-org/whisper.cpp)?
 
 1) Whisper operates on 30s audio chunks, so it is not feasible to use in interactive applications.
 NeMotron's ASR model has configurable latency (from 80ms to 1.12s), which can traded for quality and speed. (bigger lookahead gives better quality and bigger chunks require less work)
 2) Whisper has troubles on long audio streams, where NeMotron's ASR is a streaming model, works for infinite streams. It does get stuck in lowercase mode though.
-3) Quiality seems to be better
+3) Quality seems to be better
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@ Additionally, those changes also help with quantization, which has requirements 
 
 ## Development
 
-To develop this project you need to clone [ggml-org/ggml](https://github.com/ggml-org/ggml) to this directory, then build ggml with all your favorite settings. TODO: Maybe make this process more friendly? PRs welcome.
-
+First, build ggml with all your favorite settings.
 ```bash
-git clone https://github.com/ggml-org/ggml.git
+git subdmodule update --init
 mkdir ggml/build
 cd ggml/build
 cmake ..

--- a/src/nemo-ggml.cpp
+++ b/src/nemo-ggml.cpp
@@ -31,60 +31,60 @@ static void compute_pos_emb(float * data, int max_len, int d_model) {
     }
 }
 
-// Initialize backend based on requested type
-static bool init_backend(nemo_model & model, nemo_backend_type backend_type) {
+// Initialize backend based on requested name (using dynamic backend loading)
+// backend_name: specific backend to use (e.g., "CPU", "CUDA", "Vulkan", "Metal")
+// If nullptr, uses the first available backend (highest priority)
+static bool init_backend(nemo_model & model, const char * backend_name) {
     model.backend = nullptr;
-    model.backend_type = NEMO_BACKEND_CPU;  // default
+    model.backend_name = "";
 
-#ifdef GGML_USE_METAL
-    if (backend_type == NEMO_BACKEND_METAL || backend_type == NEMO_BACKEND_AUTO) {
-        model.backend = ggml_backend_metal_init();
+    // Load all available backend modules
+    ggml_backend_load_all();
+
+    if (backend_name != nullptr && backend_name[0] != '\0') {
+        // User specified a backend
+        model.backend = ggml_backend_init_by_name(backend_name, nullptr);
         if (!model.backend) {
-            fprintf(stderr, "Failed to initialize Metal backend\n");
-            assert(false);
-        }
-    }
-#endif
-
-#ifdef GGML_USE_CUDA
-    if (backend_type == NEMO_BACKEND_CUDA || backend_type == NEMO_BACKEND_AUTO) {
-        int n_devices = ggml_backend_cuda_get_device_count();
-        if (n_devices > 0) {
-            model.backend = ggml_backend_cuda_init(0);  // use first CUDA device
-            if (model.backend) {
-                model.backend_type = NEMO_BACKEND_CUDA;
-                char desc[256];
-                ggml_backend_cuda_get_device_description(0, desc, sizeof(desc));
-                printf("%s: using CUDA backend (%s)\n", __func__, desc);
-
-                size_t free_mem, total_mem;
-                ggml_backend_cuda_get_device_memory(0, &free_mem, &total_mem);
-                printf("%s: CUDA memory: %.1f / %.1f GB available\n", __func__,
-                       free_mem / 1e9, total_mem / 1e9);
-            }
-        }
-    }
-#endif
-
-    // Fall back to CPU if CUDA not available or not requested
-    if (!model.backend) {
-        if (backend_type == NEMO_BACKEND_CUDA) {
-            fprintf(stderr, "%s: CUDA backend requested but not available\n", __func__);
+            fprintf(stderr, "%s: failed to initialize %s backend\n", __func__, backend_name);
             return false;
         }
-        model.backend = ggml_backend_cpu_init();
-        model.backend_type = NEMO_BACKEND_CPU;
-        printf("%s: using CPU backend\n", __func__);
+        model.backend_name = backend_name;
+        printf("%s: using %s backend\n", __func__, backend_name);
+    } else {
+        // Auto-select: use first available backend (backends are registered in priority order)
+        size_t dev_count = ggml_backend_dev_count();
+        if (dev_count == 0) {
+            fprintf(stderr, "%s: no backends available\n", __func__);
+            return false;
+        }
+
+        // Try devices in order until one initializes successfully
+        for (size_t i = 0; i < dev_count; i++) {
+            ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+            const char * dev_name = ggml_backend_dev_name(dev);
+
+            model.backend = ggml_backend_dev_init(dev, nullptr);
+            if (model.backend) {
+                model.backend_name = dev_name;
+                printf("%s: using %s backend (auto-selected)\n", __func__, dev_name);
+                break;
+            }
+        }
+
+        if (!model.backend) {
+            fprintf(stderr, "%s: failed to initialize any backend\n", __func__);
+            return false;
+        }
     }
 
-    return model.backend != nullptr;
+    return true;
 }
 
-bool nemo_model_load(const std::string & path, nemo_model & model, nemo_backend_type backend_type) {
+bool nemo_model_load(const std::string & path, nemo_model & model, const char * backend_name) {
     // printf("%s: loading model from '%s'\n", __func__, path.c_str());
 
     // Initialize backend
-    if (!init_backend(model, backend_type)) {
+    if (!init_backend(model, backend_name)) {
         fprintf(stderr, "%s: failed to initialize backend\n", __func__);
         return false;
     }
@@ -388,13 +388,13 @@ bool nemo_model_load(const std::string & path, nemo_model & model, nemo_backend_
 }
 
 struct nemo_context * nemo_init(const char * model_path) {
-    return nemo_init_with_backend(model_path, NEMO_BACKEND_AUTO);
+    return nemo_init_with_backend(model_path, nullptr);
 }
 
-struct nemo_context * nemo_init_with_backend(const char * model_path, nemo_backend_type backend) {
+struct nemo_context * nemo_init_with_backend(const char * model_path, const char * backend_name) {
     struct nemo_context * ctx = new nemo_context();
 
-    if (!nemo_model_load(model_path, ctx->model, backend)) {
+    if (!nemo_model_load(model_path, ctx->model, backend_name)) {
         delete ctx;
         return nullptr;
     }
@@ -433,12 +433,8 @@ struct nemo_context * nemo_init_with_backend(const char * model_path, nemo_backe
 }
 
 const char * nemo_get_backend_name(struct nemo_context * ctx) {
-    if (!ctx) return "unknown";
-    switch (ctx->model.backend_type) {
-        case NEMO_BACKEND_CUDA: return "CUDA";
-        case NEMO_BACKEND_CPU:  return "CPU";
-        default: return "unknown";
-    }
+    if (!ctx || ctx->model.backend_name.empty()) return "unknown";
+    return ctx->model.backend_name.c_str();
 }
 
 void nemo_free(struct nemo_context * ctx) {

--- a/src/nemo-ggml.h
+++ b/src/nemo-ggml.h
@@ -7,13 +7,8 @@
 #include "ggml-backend.h"
 #include "gguf.h"
 
-#ifdef GGML_USE_METAL
-#include "ggml-metal.h"
-#endif
-
-#ifdef GGML_USE_CUDA
-#include "ggml-cuda.h"
-#endif
+// Backend headers not needed with dynamic loading
+// Backends are loaded via ggml_backend_init_by_name() or ggml_backend_init_by_type()
 
 #include <cstdint>
 #include <string>
@@ -21,14 +16,6 @@
 #include <map>
 
 struct timed_token;
-
-// Backend type for inference
-enum nemo_backend_type {
-    NEMO_BACKEND_CPU = 0,
-    NEMO_BACKEND_CUDA = 1,
-    NEMO_BACKEND_METAL = 2,
-    NEMO_BACKEND_AUTO = 3,  // Auto-detect: prefer CUDA if available
-};
 
 // Forward declaration
 struct nemo_preprocessor;
@@ -181,7 +168,7 @@ struct nemo_model {
     struct ggml_context * ctx_w;          // weights context
     ggml_backend_t backend;
     ggml_backend_buffer_t buffer_w;
-    nemo_backend_type backend_type;       // which backend is in use
+    std::string backend_name;             // which backend is in use
 
     // Tensor name mapping for loading
     std::map<std::string, struct ggml_tensor *> tensors;
@@ -227,11 +214,12 @@ struct nemo_context {
 };
 
 // API functions
-// Initialize with automatic backend selection (prefers CUDA if available)
+// Initialize with automatic backend selection (uses first available backend from GGML registry)
 struct nemo_context * nemo_init(const char * model_path);
 
-// Initialize with specific backend
-struct nemo_context * nemo_init_with_backend(const char * model_path, nemo_backend_type backend);
+// Initialize with specific backend by name (e.g., "CPU", "CUDA", "Vulkan", "Metal")
+// Pass nullptr for backend_name to use automatic selection
+struct nemo_context * nemo_init_with_backend(const char * model_path, const char * backend_name);
 
 void nemo_free(struct nemo_context * ctx);
 
@@ -239,7 +227,8 @@ void nemo_free(struct nemo_context * ctx);
 const char * nemo_get_backend_name(struct nemo_context * ctx);
 
 // Load model weights from file (with backend selection)
-bool nemo_model_load(const std::string & path, nemo_model & model, nemo_backend_type backend = NEMO_BACKEND_AUTO);
+// Pass nullptr for backend_name to use automatic selection
+bool nemo_model_load(const std::string & path, nemo_model & model, const char * backend_name = nullptr);
 
 // Build computation graphs
 struct ggml_cgraph * nemo_build_encoder_graph(

--- a/src/nemo-stream.cpp
+++ b/src/nemo-stream.cpp
@@ -14,6 +14,79 @@ std::string tokens_to_text(const std::vector<int> & tokens, const std::vector<ch
 // nemo_decoder_state::init and reset are now inline in nemo-ggml.h
 
 // =============================================================================
+// C-compatible nemo_cache_config helper functions
+// =============================================================================
+
+extern "C" {
+
+size_t nemo_cache_config_get_chunk_mel_frames(const nemo_cache_config* config) {
+    if (!config) return 0;
+    // NeMo formula: sampling_frames[1] + subsampling_factor * lookahead_steps
+    // where lookahead_steps = att_right_context
+    // Plus pre_encode_cache_size for the overlap
+    int32_t lookahead_steps = config->att_right_context;
+    int32_t chunk_without_cache = config->subsampling_factor + config->subsampling_factor * lookahead_steps;
+    return config->pre_encode_cache_size + chunk_without_cache;
+}
+
+size_t nemo_cache_config_get_shift_mel_frames_val(const nemo_cache_config* config) {
+    if (!config) return 0;
+    // NeMo formula: shift_size[1] = sampling_frames[1] + sampling_frames[1] * (lookahead_steps - cache_drop_size)
+    // For pure causal with cache_drop_size=0: 8 + 8*0 = 8
+    int32_t lookahead_steps = config->att_right_context;
+    return config->subsampling_factor + config->subsampling_factor * (lookahead_steps - config->cache_drop_size);
+}
+
+int32_t nemo_cache_config_get_chunk_samples(const nemo_cache_config* config) {
+    if (!config) return 0;
+    return nemo_cache_config_get_chunk_mel_frames(config) * config->hop_length;
+}
+
+int32_t nemo_cache_config_get_latency_ms(const nemo_cache_config* config) {
+    if (!config) return 0;
+    return nemo_cache_config_get_chunk_mel_frames(config) * config->hop_length * 1000 / config->sample_rate;
+}
+
+int32_t nemo_cache_config_get_valid_out_len(const nemo_cache_config* config) {
+    if (!config) return 0;
+    return 1 + config->att_right_context;
+}
+
+nemo_cache_config nemo_cache_config_default(void) {
+    return nemo_cache_config_with_latency(NEMO_LATENCY_PURE_CAUSAL);
+}
+
+nemo_cache_config nemo_cache_config_with_latency(nemo_latency_mode mode) {
+    nemo_cache_config cfg;
+    std::memset(&cfg, 0, sizeof(cfg));
+    // Set defaults
+    cfg.att_left_context = 70;
+    cfg.att_right_context = static_cast<int32_t>(mode);
+    cfg.cache_drop_size = 0;
+    cfg.conv_kernel_size = 9;
+    cfg.conv_cache_size = 8;
+    cfg.d_model = 1024;
+    cfg.n_layers = 24;
+    cfg.n_heads = 8;
+    cfg.d_head = 128;
+    cfg.subsampling_factor = 8;
+    cfg.n_mels = 128;
+    cfg.sample_rate = 16000;
+    cfg.hop_length = 160;
+    cfg.decoder_hidden = 640;
+    cfg.decoder_layers = 2;
+    cfg.vocab_size = 1025;
+    cfg.blank_token = 1024;
+    cfg.drop_extra_pre_encoded = 2;
+    cfg.last_channel_cache_size = 70;
+    cfg.pre_encode_cache_size = 9;
+    cfg.shift_mel_frames = 8;
+    return cfg;
+}
+
+} // extern "C"
+
+// =============================================================================
 // Pre-built Encoder Graph
 // =============================================================================
 
@@ -122,7 +195,7 @@ void nemo_encoder_graph::build_streaming_encoder(
     const int n_mels = cfg.n_mels;
     const int cache_len = cfg.att_left_context;
     const int conv_cache_len = cfg.conv_kernel_size - 1;
-    size_t mel_chunk_frames = cfg.get_chunk_mel_frames();
+    size_t mel_chunk_frames = nemo_cache_config_get_chunk_mel_frames(&cfg);
     // Create input tensor for mel chunk
     mel_input = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, n_mels, mel_chunk_frames, 1);
     ggml_set_name(mel_input, "mel_input");
@@ -1022,7 +1095,7 @@ static std::string process_mel_chunk_streaming(
     // =========================================================================
     // 1. Truncate encoder output to valid_out_len frames
     //    NeMo: encoded = encoded[:, :, :valid_out_len]
-    int32_t valid_out_len = sctx->config.get_valid_out_len();
+    int32_t valid_out_len = nemo_cache_config_get_valid_out_len(&sctx->config);
     if (enc_out_frames > (size_t)valid_out_len) {
         // Only use first valid_out_len frames
         enc_out_frames = valid_out_len;
@@ -1092,7 +1165,7 @@ std::string nemo_stream_process_incremental(
     // Process when we have enough mel frames for the configured chunk size
     // Add to mel buffer if not enough
     size_t total_mels = sctx->mel_buffer.size() / sctx->config.n_mels;
-    size_t graph_mel_frames = sctx->config.get_chunk_mel_frames();
+    size_t graph_mel_frames = nemo_cache_config_get_chunk_mel_frames(&sctx->config);
     if (total_mels < graph_mel_frames) {
         return "";
     }
@@ -1160,9 +1233,9 @@ std::string nemo_stream_finalize(struct nemo_stream_context* sctx) {
            (double)sctx->total_decode_iterations / sctx->total_chunks_processed);
 
     printf("\n[STREAMING STATS] Config: chunk_mel_frames=%zu, shift_mel_frames=%zu, valid_out_len=%d\n",
-           sctx->config.get_chunk_mel_frames(),
-           sctx->config.get_shift_mel_frames(),
-           sctx->config.get_valid_out_len());
+           nemo_cache_config_get_chunk_mel_frames(&sctx->config),
+           nemo_cache_config_get_shift_mel_frames_val(&sctx->config),
+           nemo_cache_config_get_valid_out_len(&sctx->config));
     printf("[STREAMING STATS] Config: att_left_context=%d, att_right_context=%d, drop_extra_pre_encoded=%d\n",
            sctx->config.att_left_context,
            sctx->config.att_right_context,

--- a/src/nemo-stream.h
+++ b/src/nemo-stream.h
@@ -2,130 +2,13 @@
 #define NEMO_STREAM_H
 
 #include "nemo-ggml.h"
+#include "nemotron_asr_types.h"
 #include <cstdint>
 #include <string>
 #include <vector>
 
-// =============================================================================
-// Cache Configuration
-// =============================================================================
-
-// Latency mode presets for streaming ASR
-// Determines how much lookahead (right context) the encoder sees
-enum class nemo_latency_mode {
-    PURE_CAUSAL   = 0,   // att_right_context=0,  80ms  latency, chunk=8 mel frames
-    ULTRA_LOW     = 1,   // att_right_context=1,  160ms latency, chunk=16 mel frames  
-    LOW           = 6,   // att_right_context=6,  560ms latency, chunk=56 mel frames
-    DEFAULT       = 13,  // att_right_context=13, 1.12s latency, chunk=112 mel frames
-};
-
-// Streaming cache configuration for Nemotron-Speech model
-struct nemo_cache_config {
-    // Attention cache settings
-    int32_t att_left_context   = 70;     // Number of past frames to cache for attention
-    int32_t att_right_context  = 0;      // Lookahead frames (0=pure causal, 1/6/13 = other modes)
-    int32_t cache_drop_size    = 0;      // Frames to drop from cache per step (0 for chunked_limited)
-
-    // Convolution cache settings
-    int32_t conv_kernel_size   = 9;      // Depthwise conv kernel size (from model config)
-    int32_t conv_cache_size    = 8;      // kernel_size - 1
-
-    // Model dimensions
-    int32_t d_model            = 1024;   // Model dimension
-    int32_t n_layers           = 24;     // Number of conformer layers
-    int32_t n_heads            = 8;      // Number of attention heads
-    int32_t d_head             = 128;    // Head dimension
-
-    // Subsampling settings
-    int32_t subsampling_factor = 8;      // Mel frames to encoder frames ratio
-    int32_t n_mels             = 128;    // Number of mel features
-
-    // Audio settings
-    int32_t sample_rate        = 16000;  // Audio sample rate
-    int32_t hop_length         = 160;    // Mel hop length (10ms at 16kHz)
-
-    // Decoder settings
-    int32_t decoder_hidden     = 640;    // LSTM hidden size
-    int32_t decoder_layers     = 2;      // Number of LSTM layers
-    int32_t vocab_size         = 1025;   // Vocabulary size (including blank)
-    int32_t blank_token        = 1024;   // Blank token ID
-
-    // Streaming post-processing settings (from NeMo streaming_cfg)
-    // valid_out_len = 1 + att_right_context (number of encoder frames to output per chunk)
-    int32_t drop_extra_pre_encoded = 2;  // Frames to drop from start after subsampling
-    int32_t last_channel_cache_size = 70; // Max size for attention cache (same as att_left_context)
-    int32_t pre_encode_cache_size = 9;   // Overlap mel frames for conv subsampling context
-    int32_t shift_mel_frames   = 8;      // Mel frames to advance per chunk (NeMo shift_size)
-    
-    // Compute chunk_mel_frames based on att_right_context
-    // This is the total mel frames needed for one encoder step (including overlap)
-    // Formula: chunk_size = pre_encode_cache_size + shift_mel_frames
-    // For pure causal: 9 + 8 = 17 mel frames = 170ms input
-    // For default (att_right_context=13): 9 + 8*(1+13) = 121 mel frames
-    size_t get_chunk_mel_frames() const {
-        // NeMo formula: sampling_frames[1] + subsampling_factor * lookahead_steps
-        // where lookahead_steps = att_right_context
-        // Plus pre_encode_cache_size for the overlap
-        int32_t lookahead_steps = att_right_context;
-        int32_t chunk_without_cache = subsampling_factor + subsampling_factor * lookahead_steps;
-        return pre_encode_cache_size + chunk_without_cache;
-    }
-
-    // Get the number of mel frames to shift/advance per chunk
-    // This determines how many new mel frames are consumed each step
-    size_t get_shift_mel_frames() const {
-        // NeMo formula: shift_size[1] = sampling_frames[1] + sampling_frames[1] * (lookahead_steps - cache_drop_size)
-        // For pure causal with cache_drop_size=0: 8 + 8*0 = 8
-        int32_t lookahead_steps = att_right_context;
-        return subsampling_factor + subsampling_factor * (lookahead_steps - cache_drop_size);
-    }
-    
-    // Compute chunk audio samples based on latency mode
-    // chunk_samples = chunk_mel_frames * hop_length
-    int32_t get_chunk_samples() const {
-        return get_chunk_mel_frames() * hop_length;
-    }
-    
-    // Get latency in milliseconds
-    int32_t get_latency_ms() const {
-        return get_chunk_mel_frames() * hop_length * 1000 / sample_rate;
-    }
-
-    // Get valid output length (encoder frames to output per chunk)
-    // For pure causal (right_context=0): 1 frame
-    // For right_context=6: 7 frames
-    // For right_context=13: 14 frames
-    int32_t get_valid_out_len() const {
-        return 1 + att_right_context;
-    }
-    
-    // Factory methods for different latency modes
-    static nemo_cache_config default_config() {
-        return with_latency(nemo_latency_mode::PURE_CAUSAL);
-    }
-    
-    static nemo_cache_config with_latency(nemo_latency_mode mode) {
-        nemo_cache_config cfg;
-        cfg.att_right_context = static_cast<int32_t>(mode);
-        return cfg;
-    }
-    
-    static nemo_cache_config pure_causal() {
-        return with_latency(nemo_latency_mode::PURE_CAUSAL);
-    }
-    
-    static nemo_cache_config ultra_low_latency() {
-        return with_latency(nemo_latency_mode::ULTRA_LOW);
-    }
-    
-    static nemo_cache_config low_latency() {
-        return with_latency(nemo_latency_mode::LOW);
-    }
-    
-    static nemo_cache_config balanced() {
-        return with_latency(nemo_latency_mode::DEFAULT);
-    }
-};
+// Note: nemo_cache_config, nemo_latency_mode, and their helper functions
+// are defined in nemotron_asr_types.h
 
 // =============================================================================
 // Decoder State - defined in nemo-ggml.h
@@ -192,7 +75,7 @@ struct nemo_stream_context {
     }
 
     size_t shift_mel_frames() const {
-        return config.get_shift_mel_frames();
+        return nemo_cache_config_get_shift_mel_frames_val(&config);
     }
 
     // Pre-built decoder/joint graph (reused across decode steps)

--- a/src/nemotron_asr_c.cpp
+++ b/src/nemotron_asr_c.cpp
@@ -1,0 +1,154 @@
+// C wrapper implementation for nemotron-asr.cpp
+// Provides C-compatible FFI interface for Rust and other languages
+
+#include "nemotron_asr_c.h"
+#include "nemo-ggml.h"
+#include "nemo-stream.h"
+
+#include <cstring>
+#include <cstdlib>
+
+// =============================================================================
+// Internal Type Casts
+// =============================================================================
+
+// Cast between C FFI and C++ types
+// These are safe because the FFI types are opaque pointers to the C++ types
+static inline ::nemo_context* to_cpp_ctx(nemo_context_ffi* ctx) {
+    return reinterpret_cast<::nemo_context*>(ctx);
+}
+
+static inline nemo_context_ffi* to_ffi_ctx(::nemo_context* ctx) {
+    return reinterpret_cast<nemo_context_ffi*>(ctx);
+}
+
+static inline ::nemo_stream_context* to_cpp_sctx(nemo_stream_context_ffi* sctx) {
+    return reinterpret_cast<::nemo_stream_context*>(sctx);
+}
+
+static inline nemo_stream_context_ffi* to_ffi_sctx(::nemo_stream_context* sctx) {
+    return reinterpret_cast<nemo_stream_context_ffi*>(sctx);
+}
+
+// Allocate and copy C++ string to C string
+static char* copy_string(const std::string& str) {
+    if (str.empty()) {
+        // Return empty string, not NULL
+        char* result = (char*)malloc(1);
+        if (result) {
+            result[0] = '\0';
+        }
+        return result;
+    }
+
+    char* result = (char*)malloc(str.length() + 1);
+    if (result) {
+        std::memcpy(result, str.c_str(), str.length() + 1);
+    }
+    return result;
+}
+
+// =============================================================================
+// Configuration Helper Functions
+// =============================================================================
+
+extern "C" {
+
+// Note: nemo_cache_config helper functions are implemented in nemo-stream.cpp
+
+// =============================================================================
+// Model Initialization and Cleanup
+// =============================================================================
+
+nemo_context_ffi* c_nemo_init_with_backend(const char* model_path, const char* backend_name) {
+    if (!model_path) return nullptr;
+
+    ::nemo_context* ctx = ::nemo_init_with_backend(model_path, backend_name);
+    return to_ffi_ctx(ctx);
+}
+
+void c_nemo_free(nemo_context_ffi* ctx) {
+    if (ctx) {
+        ::nemo_free(to_cpp_ctx(ctx));
+    }
+}
+
+const char* c_nemo_get_backend_name(nemo_context_ffi* ctx) {
+    if (!ctx) return nullptr;
+    return ::nemo_get_backend_name(to_cpp_ctx(ctx));
+}
+
+// =============================================================================
+// Streaming API
+// =============================================================================
+
+nemo_stream_context_ffi* c_nemo_stream_init(
+    nemo_context_ffi* ctx,
+    const nemo_cache_config* config
+) {
+    if (!ctx) return nullptr;
+
+    // config is already C-compatible, can pass directly
+    ::nemo_stream_context* sctx = ::nemo_stream_init(to_cpp_ctx(ctx), config);
+    return to_ffi_sctx(sctx);
+}
+
+char* c_nemo_stream_process_incremental(
+    nemo_stream_context_ffi* sctx,
+    const int16_t* audio,
+    int n_samples
+) {
+    if (!sctx || !audio) {
+        return copy_string("");
+    }
+
+    std::string result = ::nemo_stream_process_incremental(
+        to_cpp_sctx(sctx),
+        audio,
+        n_samples
+    );
+
+    return copy_string(result);
+}
+
+char* c_nemo_stream_finalize(nemo_stream_context_ffi* sctx) {
+    if (!sctx) {
+        return copy_string("");
+    }
+
+    std::string result = ::nemo_stream_finalize(to_cpp_sctx(sctx));
+    return copy_string(result);
+}
+
+char* c_nemo_stream_get_transcript(nemo_stream_context_ffi* sctx) {
+    if (!sctx) {
+        return copy_string("");
+    }
+
+    std::string result = ::nemo_stream_get_transcript(to_cpp_sctx(sctx));
+    return copy_string(result);
+}
+
+void c_nemo_stream_reset(nemo_stream_context_ffi* sctx) {
+    if (sctx) {
+        ::nemo_stream_reset(to_cpp_sctx(sctx));
+    }
+}
+
+void c_nemo_stream_free(nemo_stream_context_ffi* sctx) {
+    if (sctx) {
+        ::nemo_stream_free(to_cpp_sctx(sctx));
+    }
+}
+
+// =============================================================================
+// Memory Management
+// =============================================================================
+
+void c_nemo_free_string(char* str) {
+    if (str) {
+        free(str);
+    }
+}
+
+} // extern "C"

--- a/src/nemotron_asr_c.h
+++ b/src/nemotron_asr_c.h
@@ -1,0 +1,91 @@
+#ifndef NEMOTRON_ASR_C_H
+#define NEMOTRON_ASR_C_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+// Include the shared C-compatible types
+#include "nemotron_asr_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// =============================================================================
+// Opaque Types
+// =============================================================================
+
+// Main model context (opaque pointer to C++ nemo_context)
+// The _ffi suffix distinguishes the opaque C handle from the C++ type
+typedef struct nemo_context nemo_context_ffi;
+
+// Streaming context (opaque pointer to C++ nemo_stream_context)
+typedef struct nemo_stream_context nemo_stream_context_ffi;
+
+// Note: nemo_cache_config, nemo_latency_mode, and their helper functions
+// are defined in nemotron_asr_types.h
+
+// =============================================================================
+// Model Initialization and Cleanup
+// =============================================================================
+
+// Initialize model context with specific backend
+// backend_name: "CPU", "CUDA", "Vulkan", "Metal", etc., or NULL for auto-select
+// Returns: context pointer on success, NULL on failure
+nemo_context_ffi* c_nemo_init_with_backend(const char* model_path, const char* backend_name);
+
+// Free model context
+void c_nemo_free(nemo_context_ffi* ctx);
+
+// Get current backend name
+// Returns: backend name string (owned by context, do not free)
+const char* c_nemo_get_backend_name(nemo_context_ffi* ctx);
+
+// =============================================================================
+// Streaming API
+// =============================================================================
+
+// Initialize streaming context
+// config: cache configuration, or NULL to use default
+// Returns: streaming context pointer on success, NULL on failure
+nemo_stream_context_ffi* c_nemo_stream_init(
+    nemo_context_ffi* ctx,
+    const struct nemo_cache_config* config
+);
+
+// Process audio chunk incrementally
+// audio: int16_t PCM samples at 16kHz mono
+// n_samples: number of samples
+// Returns: C string with new transcription (may be empty), caller must free with c_nemo_free_string
+char* c_nemo_stream_process_incremental(
+    nemo_stream_context_ffi* sctx,
+    const int16_t* audio,
+    int n_samples
+);
+
+// Finalize streaming and flush remaining audio
+// Returns: C string with final transcription, caller must free with c_nemo_free_string
+char* c_nemo_stream_finalize(nemo_stream_context_ffi* sctx);
+
+// Get full accumulated transcript
+// Returns: C string with full transcript, caller must free with c_nemo_free_string
+char* c_nemo_stream_get_transcript(nemo_stream_context_ffi* sctx);
+
+// Reset streaming state (clear caches and transcript)
+void c_nemo_stream_reset(nemo_stream_context_ffi* sctx);
+
+// Free streaming context
+void c_nemo_stream_free(nemo_stream_context_ffi* sctx);
+
+// =============================================================================
+// Memory Management
+// =============================================================================
+
+// Free C string returned by library functions
+void c_nemo_free_string(char* str);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NEMOTRON_ASR_C_H

--- a/src/nemotron_asr_types.h
+++ b/src/nemotron_asr_types.h
@@ -1,0 +1,96 @@
+#ifndef NEMOTRON_ASR_TYPES_H
+#define NEMOTRON_ASR_TYPES_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// =============================================================================
+// Latency Mode Enum
+// =============================================================================
+
+// Latency mode presets for streaming ASR
+// Determines how much lookahead (right context) the encoder sees
+typedef enum {
+    NEMO_LATENCY_PURE_CAUSAL = 0,   // att_right_context=0,  80ms  latency, chunk=8 mel frames
+    NEMO_LATENCY_ULTRA_LOW   = 1,   // att_right_context=1,  160ms latency, chunk=16 mel frames
+    NEMO_LATENCY_LOW         = 6,   // att_right_context=6,  560ms latency, chunk=56 mel frames
+    NEMO_LATENCY_DEFAULT     = 13,  // att_right_context=13, 1.12s latency, chunk=112 mel frames
+} nemo_latency_mode;
+
+// =============================================================================
+// Cache Configuration Struct
+// =============================================================================
+
+// Streaming cache configuration for Nemotron-Speech model
+// This is a C-compatible POD struct with optional C++ convenience methods
+struct nemo_cache_config {
+    // Attention cache settings
+    int32_t att_left_context;      // Number of past frames to cache for attention (default: 70)
+    int32_t att_right_context;     // Lookahead frames (0=pure causal, 1/6/13 = other modes, default: 0)
+    int32_t cache_drop_size;       // Frames to drop from cache per step (default: 0 for chunked_limited)
+
+    // Convolution cache settings
+    int32_t conv_kernel_size;      // Depthwise conv kernel size (default: 9)
+    int32_t conv_cache_size;       // kernel_size - 1 (default: 8)
+
+    // Model dimensions
+    int32_t d_model;               // Model dimension (default: 1024)
+    int32_t n_layers;              // Number of conformer layers (default: 24)
+    int32_t n_heads;               // Number of attention heads (default: 8)
+    int32_t d_head;                // Head dimension (default: 128)
+
+    // Subsampling settings
+    int32_t subsampling_factor;    // Mel frames to encoder frames ratio (default: 8)
+    int32_t n_mels;                // Number of mel features (default: 128)
+
+    // Audio settings
+    int32_t sample_rate;           // Audio sample rate (default: 16000)
+    int32_t hop_length;            // Mel hop length (default: 160, 10ms at 16kHz)
+
+    // Decoder settings
+    int32_t decoder_hidden;        // LSTM hidden size (default: 640)
+    int32_t decoder_layers;        // Number of LSTM layers (default: 2)
+    int32_t vocab_size;            // Vocabulary size (default: 1025, including blank)
+    int32_t blank_token;           // Blank token ID (default: 1024)
+
+    // Streaming post-processing settings (from NeMo streaming_cfg)
+    int32_t drop_extra_pre_encoded;    // Frames to drop from start after subsampling (default: 2)
+    int32_t last_channel_cache_size;   // Max size for attention cache (default: 70)
+    int32_t pre_encode_cache_size;     // Overlap mel frames for conv subsampling context (default: 9)
+    int32_t shift_mel_frames;          // Mel frames to advance per chunk (default: 8)
+};
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+// Get chunk size in mel frames
+size_t nemo_cache_config_get_chunk_mel_frames(const struct nemo_cache_config* config);
+
+// Get shift mel frames value
+size_t nemo_cache_config_get_shift_mel_frames_val(const struct nemo_cache_config* config);
+
+// Get chunk size in audio samples
+int32_t nemo_cache_config_get_chunk_samples(const struct nemo_cache_config* config);
+
+// Get latency in milliseconds
+int32_t nemo_cache_config_get_latency_ms(const struct nemo_cache_config* config);
+
+// Get valid output length
+int32_t nemo_cache_config_get_valid_out_len(const struct nemo_cache_config* config);
+
+// Create default cache configuration
+struct nemo_cache_config nemo_cache_config_default(void);
+
+// Create cache configuration with specific latency mode
+struct nemo_cache_config nemo_cache_config_with_latency(nemo_latency_mode mode);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NEMOTRON_ASR_TYPES_H

--- a/src/transcribe.cpp
+++ b/src/transcribe.cpp
@@ -14,18 +14,17 @@
 #include <vector>
 
 static void print_usage(const char * prog) {
-    fprintf(stderr, "Usage: %s <model.gguf> <input_file> [--mel] [--cpu|--cuda]\n", prog);
+    fprintf(stderr, "Usage: %s <model.gguf> <input_file> [--mel] [--backend <name>]\n", prog);
     fprintf(stderr, "\n");
-    fprintf(stderr, "  model.gguf  - GGUF model file (convert with scripts/convert_to_gguf.py)\n");
-    fprintf(stderr, "  input_file  - Audio file (PCM i16le 16kHz mono) or mel spectrogram\n");
-    fprintf(stderr, "  --mel       - Input is mel spectrogram [time, 128] float32 (optional)\n");
-    fprintf(stderr, "  --cpu       - Force CPU backend\n");
-    fprintf(stderr, "  --cuda      - Force CUDA backend\n");
+    fprintf(stderr, "  model.gguf       - GGUF model file (convert with scripts/convert_to_gguf.py)\n");
+    fprintf(stderr, "  input_file       - Audio file (PCM i16le 16kHz mono) or mel spectrogram\n");
+    fprintf(stderr, "  --mel            - Input is mel spectrogram [time, 128] float32 (optional)\n");
+    fprintf(stderr, "  --backend <name> - Select backend (default: auto-select first available)\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Examples:\n");
-    fprintf(stderr, "  %s weights/model.gguf audio.pcm          # PCM audio input (auto backend)\n", prog);
-    fprintf(stderr, "  %s weights/model.gguf audio.pcm --cuda   # Force CUDA backend\n", prog);
-    fprintf(stderr, "  %s weights/model.gguf test.mel.bin --mel # Mel spectrogram input\n", prog);
+    fprintf(stderr, "  %s weights/model.gguf audio.pcm                 # PCM audio input (auto backend)\n", prog);
+    fprintf(stderr, "  %s weights/model.gguf audio.pcm --backend CPU   # Force CPU backend\n", prog);
+    fprintf(stderr, "  %s weights/model.gguf test.mel.bin --mel        # Mel spectrogram input\n", prog);
 }
 
 int main(int argc, char ** argv) {
@@ -38,18 +37,22 @@ int main(int argc, char ** argv) {
     const char * input_path = argv[2];
 
     // Parse optional args
-    nemo_backend_type backend = NEMO_BACKEND_AUTO;
+    const char * backend_name = nullptr;  // nullptr = auto-select
     for (int i = 3; i < argc; i++) {
-        if (strcmp(argv[i], "--cpu") == 0) {
-            backend = NEMO_BACKEND_CPU;
-        } else if (strcmp(argv[i], "--cuda") == 0) {
-            backend = NEMO_BACKEND_CUDA;
+        if (strcmp(argv[i], "--backend") == 0) {
+            if (i + 1 < argc) {
+                backend_name = argv[i + 1];
+                i++;  // skip next argument
+            } else {
+                fprintf(stderr, "Error: --backend requires a backend name\n");
+                return 1;
+            }
         }
     }
 
     // Load model
     printf("Loading model from %s...\n", model_path);
-    struct nemo_context * ctx = nemo_init_with_backend(model_path, backend);
+    struct nemo_context * ctx = nemo_init_with_backend(model_path, backend_name);
     if (!ctx) {
         fprintf(stderr, "Failed to load model\n");
         return 1;

--- a/src/transcribe_stream.cpp
+++ b/src/transcribe_stream.cpp
@@ -24,16 +24,31 @@
 #endif
 
 static void print_usage(const char * prog) {
-    fprintf(stderr, "Usage: %s <model.gguf> <audio.pcm|-|--stdin> [chunk_ms] [right_context] [--cpu|--cuda]\n", prog);
+    fprintf(stderr, "Usage: %s <model.gguf> <audio.pcm|-|--stdin> [chunk_ms] [right_context] [--backend <name>]\n", prog);
     fprintf(stderr, "\n");
     fprintf(stderr, "  model.gguf      - GGUF model file\n");
     fprintf(stderr, "  audio.pcm       - Audio file (PCM i16le 16kHz mono)\n");
     fprintf(stderr, "  - or --stdin    - Read audio from stdin\n");
     fprintf(stderr, "  chunk_ms        - Chunk size in milliseconds (default: 80)\n");
     fprintf(stderr, "  right_context   - Attention right context (0, 1, 6, or 13, default: 0)\n");
-    fprintf(stderr, "  --cpu           - Force CPU backend\n");
-    fprintf(stderr, "  --cuda          - Force CUDA backend\n");
-    fprintf(stderr, "  --metal         - Force Metal backend\n");
+    fprintf(stderr, "  --backend <name> - Select backend (default: auto-select first available)\n");
+    fprintf(stderr, "\n");
+
+    // Load backends to discover what's available
+    ggml_backend_load_all();
+    size_t dev_count = ggml_backend_dev_count();
+
+    fprintf(stderr, "Available backends:\n");
+    if (dev_count == 0) {
+        fprintf(stderr, "  (none available)\n");
+    } else {
+        for (size_t i = 0; i < dev_count; i++) {
+            ggml_backend_dev_t dev = ggml_backend_dev_get(i);
+            const char * dev_name = ggml_backend_dev_name(dev);
+            fprintf(stderr, "  %s%s\n", dev_name, i == 0 ? " (default)" : "");
+        }
+    }
+
     fprintf(stderr, "\n");
     fprintf(stderr, "Streaming modes:\n");
     fprintf(stderr, "  right_context=0  - Pure causal, 80ms latency\n");
@@ -43,10 +58,9 @@ static void print_usage(const char * prog) {
     fprintf(stderr, "\n");
     fprintf(stderr, "Examples:\n");
     fprintf(stderr, "  %s weights/model.gguf audio.pcm 80 0\n", prog);
-    fprintf(stderr, "  %s weights/model.gguf audio.pcm 80 0 --cuda\n", prog);
+    fprintf(stderr, "  %s weights/model.gguf audio.pcm 80 0 --backend Vulkan\n", prog);
     fprintf(stderr, "  ffmpeg -i audio.mp3 -f s16le -ar 16000 -ac 1 - | %s weights/model.gguf -\n", prog);
-    fprintf(stderr, "  arecord -f S16_LE -r 16000 -c 1 - | %s weights/model.gguf - 80 0 --cuda\n", prog);
-    fprintf(stderr, "  %s weights/model.gguf audio.pcm 80 0 --metal\n", prog);
+    fprintf(stderr, "  arecord -f S16_LE -r 16000 -c 1 - | %s weights/model.gguf - 80 0 --backend CPU\n", prog);
 }
 
 int main(int argc, char ** argv) {
@@ -59,29 +73,37 @@ int main(int argc, char ** argv) {
     const char * audio_path = argv[2];
     int chunk_ms = 80;  // default 80ms chunks
     int right_context = 0;  // default: pure causal
-    nemo_backend_type backend = NEMO_BACKEND_AUTO;
+    const char * backend_name = nullptr;  // nullptr = auto-select
     bool read_from_stdin = (strcmp(audio_path, "-") == 0 || strcmp(audio_path, "--stdin") == 0);
 
     // Parse arguments
+    int positional_arg = 0;  // track which positional argument we're on (after model and audio)
     for (int i = 3; i < argc; i++) {
-        if (strcmp(argv[i], "--cpu") == 0) {
-            backend = NEMO_BACKEND_CPU;
-        } else if (strcmp(argv[i], "--cuda") == 0) {
-            backend = NEMO_BACKEND_CUDA;
-        } else if (strcmp(argv[i], "--metal") == 0) {
-            backend = NEMO_BACKEND_METAL;
-        } else if (i == 3) {
-            chunk_ms = atoi(argv[i]);
-            if (chunk_ms < 10) {
-                fprintf(stderr, "Error: chunk_ms must be >= 10 (got %d)\n", chunk_ms);
+        if (strcmp(argv[i], "--backend") == 0) {
+            if (i + 1 < argc) {
+                backend_name = argv[i + 1];
+                i++;  // skip next argument
+            } else {
+                fprintf(stderr, "Error: --backend requires a backend name\n");
                 return 1;
             }
-        } else if (i == 4) {
-            right_context = atoi(argv[i]);
-            if (right_context != 0 && right_context != 1 &&
-                right_context != 6 && right_context != 13) {
-                fprintf(stderr, "Warning: non-standard right_context=%d (use 0, 1, 6, or 13)\n",
-                        right_context);
+        } else {
+            // Positional arguments: chunk_ms, then right_context
+            if (positional_arg == 0) {
+                chunk_ms = atoi(argv[i]);
+                if (chunk_ms < 10) {
+                    fprintf(stderr, "Error: chunk_ms must be >= 10 (got %d)\n", chunk_ms);
+                    return 1;
+                }
+                positional_arg++;
+            } else if (positional_arg == 1) {
+                right_context = atoi(argv[i]);
+                if (right_context != 0 && right_context != 1 &&
+                    right_context != 6 && right_context != 13) {
+                    fprintf(stderr, "Warning: non-standard right_context=%d (use 0, 1, 6, or 13)\n",
+                            right_context);
+                }
+                positional_arg++;
             }
         }
     }
@@ -98,7 +120,7 @@ int main(int argc, char ** argv) {
     fprintf(stderr, "\n");
 
     fprintf(stderr, "Loading model from %s...\n", model_path);
-    struct nemo_context * ctx = nemo_init_with_backend(model_path, backend);
+    struct nemo_context * ctx = nemo_init_with_backend(model_path, backend_name);
     if (!ctx) {
         fprintf(stderr, "Failed to load model\n");
         return 1;

--- a/src/transcribe_stream.cpp
+++ b/src/transcribe_stream.cpp
@@ -128,7 +128,7 @@ int main(int argc, char ** argv) {
     fprintf(stderr, "Model loaded successfully (backend: %s)\n", nemo_get_backend_name(ctx));
 
     // Initialize cache-aware streaming context
-    nemo_cache_config cache_cfg = nemo_cache_config::default_config();
+    nemo_cache_config cache_cfg = nemo_cache_config_default();
     cache_cfg.att_right_context = right_context;  // User-selected latency mode
 
     struct nemo_stream_context * sctx = nemo_stream_init(ctx, &cache_cfg);
@@ -138,7 +138,7 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
-    int computed_chunk_samples = cache_cfg.get_chunk_samples();
+    int computed_chunk_samples = nemo_cache_config_get_chunk_samples(&cache_cfg);
     size_t total_samples_processed = 0;
 
     // Open input source (stdin or file)

--- a/tests/test_python_reference.cpp
+++ b/tests/test_python_reference.cpp
@@ -1,8 +1,8 @@
 // Test GGML implementation against Python reference data
 // Uses numpy files exported from test_streaming_cache.py and export_layer_data.py
 
-#include "../src-ggml/nemo-ggml.h"
-#include "../src-ggml/nemo-stream.h"
+#include "../src/nemo-ggml.h"
+#include "../src/nemo-stream.h"
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/tests/test_streaming.cpp
+++ b/tests/test_streaming.cpp
@@ -112,78 +112,78 @@ bool test_latency_modes() {
     
     // Test pure causal (80ms)
     {
-        nemo_cache_config cfg = nemo_cache_config::pure_causal();
+        nemo_cache_config cfg = nemo_cache_config_with_latency(NEMO_LATENCY_PURE_CAUSAL);
         if (cfg.att_right_context != 0) {
             printf(RED "FAIL" RESET " (pure_causal right_context=%u, expected 0)\n", cfg.att_right_context);
             return false;
         }
-        if (cfg.get_chunk_mel_frames() != 8) {
-            printf(RED "FAIL" RESET " (pure_causal mel_frames=%zu, expected 8)\n", cfg.get_chunk_mel_frames());
+        if (nemo_cache_config_get_chunk_mel_frames(&cfg) != 8) {
+            printf(RED "FAIL" RESET " (pure_causal mel_frames=%zu, expected 8)\n", nemo_cache_config_get_chunk_mel_frames(&cfg));
             return false;
         }
-        if (cfg.get_latency_ms() != 80) {
-            printf(RED "FAIL" RESET " (pure_causal latency=%ums, expected 80)\n", cfg.get_latency_ms());
+        if (nemo_cache_config_get_latency_ms(&cfg) != 80) {
+            printf(RED "FAIL" RESET " (pure_causal latency=%ums, expected 80)\n", nemo_cache_config_get_latency_ms(&cfg));
             return false;
         }
     }
     
     // Test ultra-low latency (160ms)
     {
-        nemo_cache_config cfg = nemo_cache_config::ultra_low_latency();
+        nemo_cache_config cfg = nemo_cache_config_with_latency(NEMO_LATENCY_ULTRA_LOW);
         if (cfg.att_right_context != 1) {
             printf(RED "FAIL" RESET " (ultra_low right_context=%u, expected 1)\n", cfg.att_right_context);
             return false;
         }
-        if (cfg.get_chunk_mel_frames() != 16) {
-            printf(RED "FAIL" RESET " (ultra_low mel_frames=%zu, expected 16)\n", cfg.get_chunk_mel_frames());
+        if (nemo_cache_config_get_chunk_mel_frames(&cfg) != 16) {
+            printf(RED "FAIL" RESET " (ultra_low mel_frames=%zu, expected 16)\n", nemo_cache_config_get_chunk_mel_frames(&cfg));
             return false;
         }
-        if (cfg.get_latency_ms() != 160) {
-            printf(RED "FAIL" RESET " (ultra_low latency=%ums, expected 160)\n", cfg.get_latency_ms());
+        if (nemo_cache_config_get_latency_ms(&cfg) != 160) {
+            printf(RED "FAIL" RESET " (ultra_low latency=%ums, expected 160)\n", nemo_cache_config_get_latency_ms(&cfg));
             return false;
         }
     }
     
     // Test low latency (560ms)
     {
-        nemo_cache_config cfg = nemo_cache_config::low_latency();
+        nemo_cache_config cfg = nemo_cache_config_with_latency(NEMO_LATENCY_LOW);
         if (cfg.att_right_context != 6) {
             printf(RED "FAIL" RESET " (low right_context=%u, expected 6)\n", cfg.att_right_context);
             return false;
         }
-        if (cfg.get_chunk_mel_frames() != 56) {
-            printf(RED "FAIL" RESET " (low mel_frames=%zu, expected 56)\n", cfg.get_chunk_mel_frames());
+        if (nemo_cache_config_get_chunk_mel_frames(&cfg) != 56) {
+            printf(RED "FAIL" RESET " (low mel_frames=%zu, expected 56)\n", nemo_cache_config_get_chunk_mel_frames(&cfg));
             return false;
         }
-        if (cfg.get_latency_ms() != 560) {
-            printf(RED "FAIL" RESET " (low latency=%ums, expected 560)\n", cfg.get_latency_ms());
+        if (nemo_cache_config_get_latency_ms(&cfg) != 560) {
+            printf(RED "FAIL" RESET " (low latency=%ums, expected 560)\n", nemo_cache_config_get_latency_ms(&cfg));
             return false;
         }
     }
     
     // Test balanced/default (1120ms)
     {
-        nemo_cache_config cfg = nemo_cache_config::balanced();
+        nemo_cache_config cfg = nemo_cache_config_with_latency(NEMO_LATENCY_DEFAULT);
         if (cfg.att_right_context != 13) {
             printf(RED "FAIL" RESET " (balanced right_context=%u, expected 13)\n", cfg.att_right_context);
             return false;
         }
-        if (cfg.get_chunk_mel_frames() != 112) {
-            printf(RED "FAIL" RESET " (balanced mel_frames=%zu, expected 112)\n", cfg.get_chunk_mel_frames());
+        if (nemo_cache_config_get_chunk_mel_frames(&cfg) != 112) {
+            printf(RED "FAIL" RESET " (balanced mel_frames=%zu, expected 112)\n", nemo_cache_config_get_chunk_mel_frames(&cfg));
             return false;
         }
-        if (cfg.get_latency_ms() != 1120) {
-            printf(RED "FAIL" RESET " (balanced latency=%ums, expected 1120)\n", cfg.get_latency_ms());
+        if (nemo_cache_config_get_latency_ms(&cfg) != 1120) {
+            printf(RED "FAIL" RESET " (balanced latency=%ums, expected 1120)\n", nemo_cache_config_get_latency_ms(&cfg));
             return false;
         }
     }
     
     // Test get_chunk_samples calculation
     {
-        nemo_cache_config cfg = nemo_cache_config::pure_causal();
+        nemo_cache_config cfg = nemo_cache_config_with_latency(NEMO_LATENCY_PURE_CAUSAL);
         // chunk_samples = chunk_mel_frames * hop_length = 8 * 160 = 1280
-        if (cfg.get_chunk_samples() != 1280) {
-            printf(RED "FAIL" RESET " (pure_causal samples=%d, expected 1280)\n", cfg.get_chunk_samples());
+        if (nemo_cache_config_get_chunk_samples(&cfg) != 1280) {
+            printf(RED "FAIL" RESET " (pure_causal samples=%d, expected 1280)\n", nemo_cache_config_get_chunk_samples(&cfg));
             return false;
         }
     }
@@ -758,7 +758,7 @@ bool test_e2e_streaming(struct nemo_context* ctx) {
     std::string full_result = nemo_transcribe_audio(ctx, audio);
     
     // Method 2: Chunked streaming processing
-    nemo_cache_config config = nemo_cache_config::default_config();
+    nemo_cache_config config = nemo_cache_config_default();
     struct nemo_stream_context* sctx = nemo_stream_init(ctx, &config);
     if (!sctx) {
         printf(RED "FAIL" RESET " (stream init failed)\n");
@@ -766,7 +766,7 @@ bool test_e2e_streaming(struct nemo_context* ctx) {
     }
     
     std::string stream_result;
-    const int chunk_size = config.get_chunk_samples();  // Samples per chunk based on latency mode
+    const int chunk_size = nemo_cache_config_get_chunk_samples(&config);  // Samples per chunk based on latency mode
     
     for (int offset = 0; offset < duration_samples; offset += chunk_size) {
         int remaining = duration_samples - offset;
@@ -822,7 +822,7 @@ bool test_incremental_streaming(struct nemo_context* ctx) {
     }
     
     // Use incremental streaming
-    nemo_cache_config config = nemo_cache_config::default_config();
+    nemo_cache_config config = nemo_cache_config_default();
     struct nemo_stream_context* sctx = nemo_stream_init(ctx, &config);
     if (!sctx) {
         printf(RED "FAIL" RESET " (stream init failed)\n");
@@ -830,7 +830,7 @@ bool test_incremental_streaming(struct nemo_context* ctx) {
     }
     
     std::string incremental_result;
-    const int chunk_size = config.get_chunk_samples();  // Samples per chunk based on latency mode
+    const int chunk_size = nemo_cache_config_get_chunk_samples(&config);  // Samples per chunk based on latency mode
     int chunks_processed = 0;
     
     for (int offset = 0; offset < duration_samples; offset += chunk_size) {


### PR DESCRIPTION
I forked this project so that I could write rust bindings for it (https://crates.io/crates/nemotron-asr). These are the changes that I made on my fork. I figured I might as well submit them upstream to see if you were interested in including them.

This PR is split up into 4 commits, each one being a fairly isolated change:
1. **Make nemotron-asr.ccp agnostic to the GGML backend** -- this change allows nemotron-asr.cpp to target any GGML backend, not just CPU, CUDA, and Metal. I personally tested Vulkan support which works great (substantially faster than CPU.) This also adds support for `GGML_BACKEND_DL`.
2. **Add C interface for FFI** -- I rewrote some of the C++ public interfaces in a C-style, allowing me to build a library `libnemotron_asr.so` / `libnemotron_asr.a`.
3. **Add GGML as a git submodule** -- this seems to be the standard for other projects using `ggml` (see for example, [parakeet.cpp](https://github.com/jason-ni/parakeet.cpp)), and it simplifies the process of making a vendored build.
4. **Enable static linkage and overriding variables in Makefile** -- Rust programs are generally statically linked, so I wanted to allow for that option for `libnemotron_asr` and `nemotron-asr.cpp`. If `ggml` is built statically, it will be linked statically. Otherwise it will be linked dynamically.

Let me know if you'd like any changes to this PR--and it's also fine if you don't want to merge it at all. Thanks for this library, it's been working great!